### PR TITLE
Allows warning code SQL_SUCCESS_WITH_INFO to resolve with the row

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -1,4 +1,4 @@
-const { dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND } = require('idb-connector');
+const { dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND, SQL_SUCCESS_WITH_INFO } = require('idb-connector');
 
 /**
  * This function is for internal use within Statement constructor.
@@ -170,7 +170,7 @@ class Statement {
 
     return new Promise((resolve, reject) => {
       stmt.fetch((result, rc) => {
-        if (rc === SQL_SUCCESS) { // SQL_SUCCESS == 0
+        if (rc === SQL_SUCCESS || rc === SQL_SUCCESS_WITH_INFO) { // SQL_SUCCESS == 0
           resolve(result);
         } else if (rc === SQL_NO_DATA_FOUND) {
           resolve(null); // Indicates the end of the Data Set


### PR DESCRIPTION
In some occasions if fetch returns rc with SQL_SUCCESS_WITH_INFO, the row is *not* resolved with the row which would lead the client to not get their result set.