### PR TITLE
refactor: Deprecate implicitly creating a connection 

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -1,5 +1,7 @@
 const { dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND, SQL_SUCCESS_WITH_INFO } = require('idb-connector');
 
+const deprecate = require('depd')('Statement');
+
 /**
  * This function is for internal use within Statement constructor.
  * When a connection object is not provided one will be created.
@@ -24,6 +26,7 @@ function createConnection() {
 class Statement {
   constructor(connection) {
     if (!connection) {
+      deprecate('implicitly creating a connection within the constructor. You should pass a Connection object instead.');
       // eslint-disable-next-line no-param-reassign
       connection = createConnection();
     }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "homepage": "https://github.com/IBM/nodejs-idb-pconnector#readme",
   "dependencies": {
+    "depd": "^2.0.0",
     "idb-connector": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Added [depd](https://www.npmjs.com/package/depd) to provide formatted deprecation warnings, like the one shown below:

![image](https://user-images.githubusercontent.com/33973272/73007946-181a6c00-3dd3-11ea-8ae2-6da88917048a.png)

In the next major version, we will drop support for this feature.

resolves #42 