### PR TITLE
ci: Add exempt issue label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,7 @@ jobs:
         stale-issue-message: ':wave: Hi! This issue has been marked stale due to inactivity. If no further activity occurs, it will automatically be closed.'
         stale-pr-message: ':wave: Hi! This pull request has been marked stale due to inactivity. If no further activity occurs, it will automatically be closed.'
         stale-issue-label: 'stale'
+        exempt-issue-label: 'keep-open'
         stale-pr-label: 'stale'
         days-before-stale: 30
         days-before-close: 7


### PR DESCRIPTION
- This will prevent our stale action from closing issues with
  the keep-open label.

Resolves #74 