### PR TITLE
feat: DBPool now emits 'new connection' event

### DIFF
--- a/lib/dbPool.js
+++ b/lib/dbPool.js
@@ -1,10 +1,12 @@
+const EventEmitter = require('events');
+
 const {
   CLOB, CHAR, INT, NUMERIC, NULL, BOOLEAN, BINARY, IN, OUT, INOUT,
 } = require('idb-connector');
 
 const DBPoolConnection = require('./dbPoolConnection');
 
-class DBPool {
+class DBPool extends EventEmitter {
   /**
    * Manages a list of DBPoolConnection instances.
    * Constructor to instantiate a new instance of a DBPool class given the `database` and `config`
@@ -18,6 +20,7 @@ class DBPool {
     incrementSize: 8,
     debug: false,
   }) {
+    super();
     const {
       incrementSize,
       debug,
@@ -31,10 +34,6 @@ class DBPool {
     };
     this.incrementSize = incrementSize || 8;
     this.debug = debug || false;
-
-    for (let i = 0; i < this.incrementSize; i += 1) {
-      this.createConnection(i);
-    }
   }
 
   /**
@@ -50,12 +49,14 @@ class DBPool {
     }
 
     this.log(`Creating Connection ${index}...`);
-    this.connections.push(new DBPoolConnection(index, {
+    const poolConnection = new DBPoolConnection(index, {
       database: this.database,
       options: {
         debug: this.debug,
       },
-    }));
+    });
+    this.connections.push(poolConnection);
+    this.emit('new connection', poolConnection.connection);
     this.log(`Connection ${index} created`);
   }
 
@@ -151,6 +152,16 @@ class DBPool {
     let connection;
     let i;
     let j;
+
+    // initialize pool if its empty
+    if (!connectionsLength) {
+      this.log('Initializing the pool');
+      for (let iter = 0; iter < this.incrementSize; iter += 1) {
+        this.createConnection(iter);
+      }
+      connections[0].setAvailable(false);
+      return connections[0];
+    }
 
     this.log('Finding available Connection...');
     while (!validConnection) {

--- a/test/dbpoolTest.js
+++ b/test/dbpoolTest.js
@@ -12,6 +12,7 @@ const idbp = require('../lib/idb-pconnector');
 
 const { DBPool } = idbp;
 const DBPoolConnection = require('../lib/dbPoolConnection');
+const Connection = require('../lib/connection');
 
 describe('DBPool Class Tests', () => {
   describe('createConnection', async () => {
@@ -116,7 +117,7 @@ describe('DBPool Class Tests', () => {
   describe('retireAll', async () => {
     it('removes all connections from the pool', async () => {
       const pool = new DBPool({ url: '*LOCAL' });
-
+      pool.attach();
       expect(pool.connections.length).to.equal(8);
 
       await pool.retireAll();
@@ -215,5 +216,16 @@ describe('DBPool Class Tests', () => {
           throw error;
         });
       });
+  });
+  describe('new connection event', () => {
+    it('executes a callback when new connection event occurs', (done) => {
+      const pool = new DBPool({ url: '*LOCAL' });
+      // register the listener
+      pool.on('new connection', (connection) => {
+        expect(connection).to.be.instanceof(Connection);
+        done();
+      });
+      pool.createConnection();
+    });
   });
 });


### PR DESCRIPTION
This allows users to do prep work on new connections like setting up the library list.

Initialization of the pool now occurs on the first call to attach()
instead of during the creation of the pool object.

This was done to capture the new connection event.

Resolves #46 