### PR TITLE
refactor: Statement tests

### DIFF
--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -19,7 +19,7 @@ const procedure = 'MAXBAL';
 
 describe('Statement Class Tests', () => {
   before('setup schema for tests', async function () {
-    this.timeout(0);
+    this.timeout(0); // disbale timeout for hook
     const connection = new Connection({ url: '*LOCAL' });
     const statement = connection.getStatement();
 
@@ -43,7 +43,7 @@ describe('Statement Class Tests', () => {
   });
 
   after('drop objects after the tests', async function () {
-    this.timeout(0);
+    this.timeout(0); // disbale timeout for hook
     const connection = new Connection({ url: '*LOCAL' });
     const statement = connection.getStatement();
 

--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -28,7 +28,7 @@ describe('Statement Class Tests', () => {
       await statement.exec(`CREATE SCHEMA ${schema}`);
     }
 
-    await statement.exec(`CREATE OR REPLACE TABLE ${schema}.${table}(team VARCHAR(100) ALLOCATE(20), score INTEGER);`);
+    await statement.exec(`CREATE OR REPLACE TABLE ${schema}.${table}(team VARCHAR(100), score INTEGER);`);
   });
 
   describe('constructor with connection parameter', () => {

--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -9,33 +9,31 @@
 const { expect } = require('chai');
 
 const {
-  Connection, Statement, DBPool, IN, OUT, NUMERIC, CHAR, SQL_ATTR_FOR_FETCH_ONLY, NULL,
+  Connection, Statement, IN, OUT, NUMERIC, INT, CHAR, SQL_ATTR_FOR_FETCH_ONLY, NULL,
 } = require('../lib/idb-pconnector');
 
 const schema = 'IDBPTEST';
+const table = 'SCORES';
+const procedure = 'MAXBAL';
 
 describe('Statement Class Tests', () => {
   before('setup schema for tests', async () => {
-    const pool = new DBPool({ url: '*LOCAL' }, { incrementSize: 2 });
-    const createSchema = `CREATE SCHEMA ${schema}`;
-    const findSchema = `SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = '${schema}'`;
+    const connection = new Connection({ url: '*LOCAL' });
+    const statement = connection.getStatement();
 
-    const schemaResult = await pool.runSql(findSchema);
+    const schemaResult = await statement.exec(`SELECT SCHEMA_NAME FROM qsys2.sysschemas WHERE SCHEMA_NAME = '${schema}'`);
+    await statement.closeCursor();
 
     if (!schemaResult.length) {
-      await pool.runSql(createSchema).catch((error) => {
-        // eslint-disable-next-line no-console
-        console.log(`UNABLE TO CREATE ${schema} SCHEMA!`);
-        throw error;
-      });
-      // eslint-disable-next-line no-console
-      console.log(`before hook: CREATED ${schema}`);
+      await statement.exec(`CREATE SCHEMA ${schema}`);
     }
+
+    await statement.exec(`CREATE OR REPLACE TABLE ${schema}.${table}(team VARCHAR(100) ALLOCATE(20), score INTEGER);`);
   });
 
   describe('constructor with connection parameter', () => {
     it('creates a new Statement object by passing a connection object', async () => {
-      const connection = new Connection().connect();
+      const connection = new Connection({ url: '*LOCAL' });
       const statement = new Statement(connection);
 
       const results = await statement.exec('SELECT * FROM QIWS.QCUSTCDT');
@@ -91,8 +89,8 @@ describe('Statement Class Tests', () => {
 
   describe('prepare', () => {
     it('prepares an sql statement', async () => {
-      const connection = new Connection();
-      const statement = connection.connect().getStatement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       const result = await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       expect(result).to.be.a('undefined');
@@ -100,130 +98,119 @@ describe('Statement Class Tests', () => {
   });
 
   describe('bindParams', () => {
-    before('create table for test', async () => {
-      const pool = new DBPool({ url: '*LOCAL' }, { incrementSize: 2 });
-      const createTable = `CREATE TABLE ${schema}.SCORES(team VARCHAR(100) ALLOCATE(20), score INTEGER)`;
-      const findTable = `SELECT OBJLONGNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${schema}', '*FILE')) AS X WHERE OBJLONGNAME = 'SCORES'`;
-
-      const tableResult = await pool.runSql(findTable);
-
-      if (!tableResult.length) {
-        await pool.runSql(createTable).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('Unable to create SCORES table');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('before hook: CREATED SCORES TABLE');
-      }
+    afterEach(async () => {
+      // runs after all tests in this block
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
+      await statement.exec(`DELETE FROM ${schema}.${table}`);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
 
     it('associate parameter markers in an SQL to app variables', async () => {
-      const sql = 'INSERT INTO QIWS.QCUSTCDT(CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) VALUES (?,?,?,?,?,?,?,?,?,?,?) with NONE';
-
-      const statement = new Statement();
-      const statement2 = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       const params = [
-        [9997, IN, NUMERIC], // CUSNUM
-        ['Doe', IN, CHAR], // LASTNAME
-        ['J D', IN, CHAR], // INITIAL
-        ['123 Broadway', IN, CHAR], // ADDRESS
-        ['Hope', IN, CHAR], // CITY
-        ['WA', IN, CHAR], // STATE
-        [98101, IN, NUMERIC], // ZIP
-        [2000, IN, NUMERIC], // CREDIT LIMIT
-        [1, IN, NUMERIC], // change
-        [250.99, IN, NUMERIC], // BAL DUE
-        [0.78, IN, NUMERIC], // CREDIT DUE
+        ['Tigers', IN, CHAR],
+        [35, IN, INT],
       ];
 
-      const countResult = await statement2.exec('SELECT COUNT(CUSNUM) AS COUNT FROM QIWS.QCUSTCDT');
-
-      const rowsBeforeCount = Number.parseInt(countResult[0].COUNT, 10);
-      await statement.prepare(sql);
+      await statement.prepare(`INSERT INTO ${schema}.${table}(TEAM, SCORE) VALUES (?,?)`);
       await statement.bindParam(params);
       await statement.execute();
 
-      const countResultAgain = await statement.exec('SELECT COUNT(CUSNUM) AS COUNT FROM QIWS.QCUSTCDT');
+      const result = await statement.exec(`SELECT COUNT(TEAM) AS COUNT FROM  ${schema}.${table}`);
 
-      const rowsAfterCount = Number.parseInt(countResultAgain[0].COUNT, 10);
-
-      expect(rowsAfterCount).to.equal(rowsBeforeCount + 1);
+      const count = Number.parseInt(result[0].COUNT, 10);
+      expect(count).to.equal(1);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
 
     it('binds a null value, tests issue #40', async () => {
-      const sql = `INSERT INTO ${schema}.SCORES(TEAM, SCORE) VALUES (?,?)`;
-
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       const params = [
-        ['EXAMPLE', IN, CHAR], // TEAM
-        [null, IN, NULL], // SCORE
+        ['EXAMPLE', IN, CHAR],
+        [null, IN, NULL],
       ];
 
-      await statement.prepare(sql);
+      await statement.prepare(`INSERT INTO ${schema}.${table}(TEAM, SCORE) VALUES (?,?)`);
       await statement.bindParam(params);
       await statement.execute();
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('close', () => {
     it('frees the statement object. ', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.exec('SELECT * FROM QIWS.QCUSTCDT');
       const result = await statement.close();
       expect(result).to.equal(true);
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   // TODO: Ensure This a correct test for how closeCursor() may be used.
   describe('closeCursor', () => {
     it('discards any pending results', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.exec('SELECT * FROM QIWS.QCUSTCDT');
       const result = await statement.closeCursor();
       expect(result).to.equal(true);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('commit', () => {
+    after(async () => {
+      // runs after all tests in this block
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
+      await statement.exec(`DELETE FROM ${schema}.${table}`);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
+    });
     it('adds changes to the database', async () => {
-      const sql = 'INSERT INTO QIWS.QCUSTCDT(CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) VALUES (?,?,?,?,?,?,?,?,?,?,?) with NONE ';
-
-      const statement = new Statement();
-
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
       const params = [
-        [9997, IN, NUMERIC], // CUSNUM
-        ['Johnson', IN, CHAR], // LASTNAME
-        ['A J', IN, CHAR], // INITIAL
-        ['453 Example', IN, CHAR], // ADDRESS
-        ['Fort', IN, CHAR], // CITY
-        ['TN', IN, CHAR], // STATE
-        [37211, IN, NUMERIC], // ZIP
-        [1000, IN, NUMERIC], // CREDIT LIMIT
-        [1, IN, NUMERIC], // change
-        [150, IN, NUMERIC], // BAL DUE
-        [0.00, IN, NUMERIC], // CREDIT DUE
+        ['Lions', IN, CHAR],
+        [13, IN, INT],
       ];
-      await statement.prepare(sql);
+
+      await statement.prepare(`INSERT INTO ${schema}.${table}(TEAM, SCORE) VALUES (?,?)`);
       await statement.bindParam(params);
       await statement.execute();
       const result = await statement.commit();
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
       expect(result).to.equal(true);
     });
   });
 
   describe('exec', () => {
     it('directly executes a given SQL String', async () => {
-      const connection = new Connection();
-      const statement = connection.connect().getStatement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
-      const sql = 'SELECT * FROM QIWS.QCUSTCDT WHERE CUSNUM = 938472';
-
-      const result = await statement.exec(sql);
+      const result = await statement.exec('SELECT * FROM QIWS.QCUSTCDT WHERE CUSNUM = 938472');
 
       expect(result).to.be.an('array');
       expect(result.length).to.be.greaterThan(0);
@@ -231,38 +218,32 @@ describe('Statement Class Tests', () => {
   });
 
   describe('execute', () => {
-    before('init stored procedure', async () => {
-      const pool = new DBPool({ url: '*LOCAL' });
-      const findSp = `SELECT OBJLONGNAME FROM TABLE (QSYS2.OBJECT_STATISTICS('${schema}', '*PGM')) AS X`;
-
-      const spResult = await pool.runSql(findSp);
-      if (!spResult.length) {
-        const createSP = `CREATE PROCEDURE ${schema}.MAXBAL (OUT OUTPUT DECIMAL(6,2))
-      BEGIN
-      DECLARE MAXBAL NUMERIC ( 6 , 2 ) ;
-      SELECT MAX ( BALDUE ) INTO MAXBAL FROM QIWS.QCUSTCDT;
-      SET OUTPUT = MAXBAL;
-      END`;
-
-        await pool.runSql(createSP).catch((error) => {
-          // eslint-disable-next-line no-console
-          console.log('UNABLE TO CREATE STORED PROCEDURE!');
-          throw error;
-        });
-        // eslint-disable-next-line no-console
-        console.log('before hook: Created Stored Procedure');
-      }
+    before('create stored procedure for test', async () => {
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = new Statement(connection);
+      const createSP = `CREATE OR REPLACE PROCEDURE ${schema}.${procedure} (OUT OUTPUT DECIMAL(6,2))
+                        BEGIN
+                        DECLARE MAXBAL NUMERIC ( 6 , 2 ) ;
+                        SELECT MAX ( BALDUE ) INTO ${procedure} FROM QIWS.QCUSTCDT;
+                        SET OUTPUT = MAXBAL;
+                        END`;
+      await statement.exec(createSP);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
 
     it('executes a stored procedure and returns output parameter', async () => {
-      const connection = new Connection();
+      const connection = new Connection({ url: '*LOCAL' });
 
-      const statement = connection.connect().getStatement();
+      const statement = connection.getStatement();
       const bal = 0;
 
-      await statement.prepare(`CALL ${schema}.MAXBAL(?)`);
+      await statement.prepare(`CALL ${schema}.${procedure}(?)`);
       await statement.bind([[bal, OUT, NUMERIC]]);
       const result = await statement.execute();
+      await connection.disconn();
+      await connection.close();
 
       expect(result).to.be.a('array');
       expect(result.length).to.equal(1);
@@ -272,12 +253,15 @@ describe('Statement Class Tests', () => {
 
   describe('fetchAll', () => {
     it('fetches All rows from the result set', async () => {
-      const connection = new Connection();
-      const statement = connection.connect().getStatement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const results = await statement.fetchAll();
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(results).to.be.a('array');
       expect(results.length).to.be.greaterThan(0);
@@ -302,12 +286,15 @@ describe('Statement Class Tests', () => {
 
   describe('fetch', () => {
     it('fetches one row from the result set', async () => {
-      const connection = new Connection();
-      const statement = connection.connect().getStatement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const result = await statement.fetch();
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(result).to.be.a('object');
       expect(result).to.haveOwnProperty('CUSNUM');
@@ -327,101 +314,121 @@ describe('Statement Class Tests', () => {
 
   describe('numFields', () => {
     it('returns number of fields contained in result', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const fields = await statement.numFields();
-
       expect(fields).to.be.a('number').to.equal(11);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('numRows', () => {
+    after(async () => {
+      // runs after all tests in this block
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
+      await statement.exec(`DELETE FROM ${schema}.${table}`);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
+    });
     it('returns number of rows that were effected by a query', async () => {
-      const sql = 'INSERT INTO QIWS.QCUSTCDT(CUSNUM,LSTNAM,INIT,STREET,CITY,STATE,ZIPCOD,CDTLMT,CHGCOD,BALDUE,CDTDUE) VALUES (?,?,?,?,?,?,?,?,?,?,?) with NONE ';
-
-      const statement = new Statement();
-
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
       const params = [
-        [9997, IN, NUMERIC], // CUSNUM
-        ['Johnson', IN, CHAR], // LAST NAME
-        ['A J', IN, CHAR], // INITIAL
-        ['453 Example', IN, CHAR], // ADDRESS
-        ['Fort', IN, CHAR], // CITY
-        ['TN', IN, CHAR], // STATE
-        [37211, IN, NUMERIC], // ZIP
-        [1000, IN, NUMERIC], // CREDIT LIMIT
-        [1, IN, NUMERIC], // change
-        [150, IN, NUMERIC], // BAL DUE
-        [0.00, IN, NUMERIC], // CREDIT DUE
+        ['Jaguars', IN, CHAR],
+        [20, IN, INT],
       ];
-      await statement.prepare(sql);
+
+      await statement.prepare(`INSERT INTO ${schema}.${table}(TEAM, SCORE) VALUES (?,?)`);
       await statement.bindParam(params);
       await statement.execute();
       const rows = await statement.numRows();
-
       expect(rows).to.be.a('number').and.to.equal(1);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('fieldType', () => {
     it('returns the data type of the indicated column', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
 
       const type = await statement.fieldType(0);
-
       expect(type).to.be.a('number').and.to.equal(2);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('fieldWidth', () => {
     it('returns the field width of the indicated column', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const width = await statement.fieldWidth(0);
-
       expect(width).to.to.equal(7);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('fieldNullable', () => {
     it('returns t/f if the indicated column is nullable', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const nullable = await statement.fieldNullable(0);
-
       expect(nullable).to.equal(false);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('fieldName', () => {
     it('returns name of the indicated column ', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const name = await statement.fieldName(0);
-
       expect(name).to.equal('CUSNUM');
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
     });
   });
 
   describe('fieldPrecise', () => {
     it('returns the precision of the indicated column', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
 
       const precision = await statement.fieldPrecise(0);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(precision).to.equal(6);
     });
@@ -429,11 +436,15 @@ describe('Statement Class Tests', () => {
 
   describe('fieldScale', () => {
     it('returns the scale of the indicated column', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const scale = await statement.fieldScale(0);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(scale).to.equal(0);
     });
@@ -444,8 +455,13 @@ describe('Statement Class Tests', () => {
       const attr = SQL_ATTR_FOR_FETCH_ONLY;
       const value = 1;
 
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
+
       const result = await statement.setStmtAttr(attr, value);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
       expect(result).to.equal(true);
     });
   });
@@ -453,9 +469,13 @@ describe('Statement Class Tests', () => {
   describe('getStmtAttr', () => {
     it('returns the value of specified attribute', async () => {
       const attr = SQL_ATTR_FOR_FETCH_ONLY;
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       const result = await statement.getStmtAttr(attr);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(result).to.equal(0);
     });
@@ -463,11 +483,15 @@ describe('Statement Class Tests', () => {
 
   describe('rollback', () => {
     it('rollback changes made on the connection', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
 
       await statement.prepare('SELECT * FROM QIWS.QCUSTCDT');
       await statement.execute();
       const result = await statement.rollback();
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
 
       expect(result).to.equal(true);
     });
@@ -475,7 +499,8 @@ describe('Statement Class Tests', () => {
 
   describe('enableNumericTypeConversion', () => {
     it('should default to false', async () => {
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
       expect(statement.enableNumericTypeConversion()).to.equal(false);
     });
 
@@ -484,8 +509,12 @@ describe('Statement Class Tests', () => {
       cast(+32767 as SMALLINT) MAX_SMALLINT
       from sysibm.sysdummy1`;
 
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
       const result = await statement.exec(sql);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
       expect(result).to.be.an('array');
       expect(result.length).to.be.greaterThan(0);
       expect(result).to.eql([{ MIN_SMALLINT: '-32768', MAX_SMALLINT: '32767' }]);
@@ -505,9 +534,13 @@ describe('Statement Class Tests', () => {
         cast(9999999999999999 as DECIMAL(16,0)) as DEC_NOT_SAFE_16_0
          from sysibm.sysdummy1`;
 
-      const statement = new Statement();
+      const connection = new Connection({ url: '*LOCAL' });
+      const statement = connection.getStatement();
       expect(statement.enableNumericTypeConversion(true)).to.equal(true);
       const result = await statement.exec(sql);
+      await statement.close();
+      await connection.disconn();
+      await connection.close();
       expect(result).to.be.an('array');
       expect(result.length).to.be.greaterThan(0);
       expect(result).to.eql([{


### PR DESCRIPTION
- No longer use deprecated Statement with implicitly connection
- No longer use QIWS.QCUSTCDT from insert tests
- Add after/afterEach hooks to delete data inserted by test cases
- Close out open statement and connection handles in each test

Resolves #77 