### PR TITLE
ci: Add npm publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,19 +2,10 @@ name: publish
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Revised version of the [npm publish workflow](https://github.com/actions/starter-workflows/blob/master/ci/npm-publish.yml) .

- Excluded `npm test` and `npm install` commands which would require an IBM i machine.

- Adjusted to run the action on release `published` rather than `created`.

- Excluded publishing to github package registry.

To make this all work we will need to add [npm_token secret]() to this repo.

Resolves #61 

