### PR TITLE
ci: fix eslint action runner

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           node-version: 16
       - run: rm package.json && rm package-lock.json
-      - run: npm install eslint@8.26.0 eslint-config-airbnb-base@15.0.0 eslint-plugin-import@2.26.0
+      - run: npm install eslint@8.26.0 eslint-config-airbnb-base@15.0.0 eslint-plugin-import@2.26.0 chai@4.3.6
       - run: ./node_modules/eslint/bin/eslint.js lib/ test/

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      # only install dev-deps, idb-connector only installs on IBM i
-      - run: npm install --only=dev --no-package-lock
-      - run: npm run lint
+      - run: rm package.json && rm package-lock.json
+      - run: npm install eslint@8.26.0 eslint-config-airbnb-base@15.0.0 eslint-plugin-import@2.26.0
+      - run: ./node_modules/eslint/bin/eslint.js lib/ test/

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 const { dbconn, SQL_ATTR_DBC_SYS_NAMING, SQL_TRUE } = require('idb-connector');
 const Statement = require('./statement');
 

--- a/lib/dbPool.js
+++ b/lib/dbPool.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 const {
   CLOB, CHAR, INT, NUMERIC, NULL, BOOLEAN, BINARY, IN, OUT, INOUT,
 } = require('idb-connector');
@@ -101,7 +102,6 @@ class DBPool {
     }
     return true;
   }
-
 
   /**
    * Frees a connection (Returns the connection "Available" back to true)
@@ -435,6 +435,5 @@ class DBPool {
     }
   }
 }
-
 
 module.exports = DBPool;

--- a/lib/idb-pconnector.js
+++ b/lib/idb-pconnector.js
@@ -2,7 +2,7 @@
   Main entry point
   exports Connection, Statement, DBPool, and idb-connector constants
 */
-
+/* eslint-disable import/no-unresolved */
 const idb = require('idb-connector');
 const Connection = require('./connection');
 const Statement = require('./statement');

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-unresolved */
 const { dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND, SQL_SUCCESS_WITH_INFO } = require('idb-connector');
 
 const deprecate = require('depd')('Statement');

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/no-unresolved */
-const { dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND, SQL_SUCCESS_WITH_INFO } = require('idb-connector');
+const {
+  dbstmt, SQL_SUCCESS, SQL_NO_DATA_FOUND, SQL_SUCCESS_WITH_INFO,
+} = require('idb-connector');
 
 const deprecate = require('depd')('Statement');
 

--- a/test/connectionTest.js
+++ b/test/connectionTest.js
@@ -8,6 +8,7 @@
 /* eslint-env mocha */
 
 const { expect } = require('chai');
+const { dbconn, dbstmt } = require('idb-connector');
 const { Connection } = require('../lib/idb-pconnector');
 const { dbconn, dbstmt } = require('idb-connector');
 

--- a/test/connectionTest.js
+++ b/test/connectionTest.js
@@ -8,6 +8,7 @@
 /* eslint-env mocha */
 
 const { expect } = require('chai');
+/* eslint-disable import/no-unresolved */
 const { dbconn, dbstmt } = require('idb-connector');
 const { Connection } = require('../lib/idb-pconnector');
 

--- a/test/connectionTest.js
+++ b/test/connectionTest.js
@@ -10,7 +10,6 @@
 const { expect } = require('chai');
 const { dbconn, dbstmt } = require('idb-connector');
 const { Connection } = require('../lib/idb-pconnector');
-const { dbconn, dbstmt } = require('idb-connector');
 
 describe('Connection Class Tests', () => {
   describe('constructor', () => {

--- a/test/dbpoolTest.js
+++ b/test/dbpoolTest.js
@@ -146,7 +146,8 @@ describe('DBPool Class Tests', () => {
   });
 
   describe('prepareExecute', async () => {
-    it('prepares, binds, and executes statement, returns output params & result set',
+    it(
+      'prepares, binds, and executes statement, returns output params & result set',
       async () => {
         const pool = new DBPool({ url: '*LOCAL' });
 
@@ -159,9 +160,11 @@ describe('DBPool Class Tests', () => {
         expect(resultSet.length).to.be.gt(0);
         expect(outputParams).to.be.an('array');
         expect(outputParams.length).to.equal(1);
-      });
+      },
+    );
 
-    it('prepares, binds, and executes statement returns null (no output or result set)',
+    it(
+      'prepares, binds, and executes statement returns null (no output or result set)',
       async () => {
         const pool = new DBPool({ url: '*LOCAL' });
 
@@ -184,9 +187,11 @@ describe('DBPool Class Tests', () => {
         const results = await pool.prepareExecute(sql, params, { io: 'in' });
 
         expect(results).to.equal(null);
-      });
+      },
+    );
 
-    it('prepares and executes INSERT returns result set only',
+    it(
+      'prepares and executes INSERT returns result set only',
       async () => {
         const pool = new DBPool({ url: '*LOCAL' });
 
@@ -197,11 +202,13 @@ describe('DBPool Class Tests', () => {
         expect(results.outputParams).to.equal(undefined);
         expect(results.resultSet).to.be.a('array');
         expect(results.resultSet.length).to.be.gt(0);
-      });
+      },
+    );
   });
 
   describe('setConnectionAttribute', async () => {
-    it('sets connection attribute for all connections in the pool.',
+    it(
+      'sets connection attribute for all connections in the pool.',
       async () => {
         const db = { url: '*LOCAL' };
 
@@ -214,7 +221,8 @@ describe('DBPool Class Tests', () => {
         await testPool.setConnectionAttribute(attribute).catch((error) => {
           throw error;
         });
-      });
+      },
+    );
   });
 
   describe('enableNumericTypeConversion', () => {

--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -16,7 +16,6 @@ const schema = 'IDBPTEST';
 const table = 'SCORES';
 const procedure = 'MAXBAL';
 
-
 describe('Statement Class Tests', () => {
   before('setup schema for tests', async function () {
     this.timeout(0); // disbale timeout for hook
@@ -82,7 +81,8 @@ describe('Statement Class Tests', () => {
   });
 
   describe('constructor without connection parameter', () => {
-    it('creates a new Statement object with implicit connection object connected to *LOCAL',
+    it(
+      'creates a new Statement object with implicit connection object connected to *LOCAL',
       async () => {
         const statement = new Statement();
 
@@ -106,7 +106,8 @@ describe('Statement Class Tests', () => {
           expect(row).to.haveOwnProperty('BALDUE');
           expect(row).to.haveOwnProperty('CDTDUE');
         });
-      });
+      },
+    );
   });
 
   describe('prepare', () => {

--- a/test/statementTest.js
+++ b/test/statementTest.js
@@ -17,7 +17,7 @@ const table = 'SCORES';
 const procedure = 'MAXBAL';
 
 describe('Statement Class Tests', () => {
-  before('setup schema for tests', async function () {
+  before('setup schema for tests', async function a() {
     this.timeout(0); // disbale timeout for hook
     const connection = new Connection({ url: '*LOCAL' });
     const statement = connection.getStatement();
@@ -35,13 +35,12 @@ describe('Statement Class Tests', () => {
                           DECLARE MAXBAL NUMERIC ( 6 , 2 ) ;
                           SELECT MAX ( BALDUE ) INTO ${procedure} FROM QIWS.QCUSTCDT;
                           SET OUTPUT = MAXBAL;
-                          END`
-                        );
+                          END`);
     await statement.close();
     await connection.close();
   });
 
-  after('drop objects after the tests', async function () {
+  after('drop objects after the tests', async function b() {
     this.timeout(0); // disbale timeout for hook
     const connection = new Connection({ url: '*LOCAL' });
     const statement = connection.getStatement();


### PR DESCRIPTION
Running npm install even with --only=dev kept attempting to install idb-connector. This fails to install causing the action to abort. Now we verbosely install the eslint deps and run the linter.